### PR TITLE
Add #coerce for arbitrary coercions

### DIFF
--- a/lib/fast_attributes.rb
+++ b/lib/fast_attributes.rb
@@ -42,6 +42,10 @@ module FastAttributes
         type_casting[type_or_class] = type_cast
       end
     end
+
+    def coerce(object, type)
+      Builder.coerce(object, type)
+    end
   end
 
   def define_attributes(options = {}, &block)

--- a/lib/fast_attributes/builder.rb
+++ b/lib/fast_attributes/builder.rb
@@ -33,6 +33,15 @@ module FastAttributes
       include_methods
     end
 
+    def self.coerce(value, type)
+        type_cast   = FastAttributes.get_type_casting(type)
+        method_body = type_cast.compile_method_body(value, 'value')
+
+        binding.eval <<-EOS, __FILE__, __LINE__ + 1
+          #{method_body}
+        EOS
+    end
+
     private
 
     def compile_getter


### PR DESCRIPTION
I'm not sure that this PR fits inside the intent of `fast_attributes`, but I wanted to contribute it back in case.

I was using `fast_attributes` and wanted to coerce arbitrary values using the nice scaffolding that `fast_attributes` provides.

ie, I don't want to convert the whole class, but I'd like to `FastAttributes.coerce(nil, String)` with more complicated or domain specific coercions.  FastAttributes provides a very nice set of tools for packaging coercions :smile_cat:.

So I added a `#coerce` method and aliased it into primary namespace.

If this isn't an implementation you like (it was an hour of my evening, so there's room for improvement), or if it's outside of the scope of `fast_attributes`, no worries. If that's the case, I'll probably wrap up a micro gem so I can reuse this behavior.

And thanks for writing `fast_attributes`! I'm really enjoying using it and see some good applications for it, especially at the boundary of services.