### PR TITLE
Added `attributes: :accessors` option to `define_attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,30 @@ book.attributes
 {"author" => "Some String"}
 ```
 
+## Attributes via accessors
+
+Sometimes you want `attributes` to return the value of your accessors, rather than the instance variables.
+This is slower than using ivars directly, so use `attributes: :accessors`:
+
+```ruby
+class Book
+  extend FastAttributes
+
+  define_attributes attributes: :accessors do
+    attribute :author, String
+  end
+
+  def author
+    @author || "No author set"
+  end
+end
+
+book = Book.new
+book.attributes
+{"author" => "No author set"}
+```
+
+
 ## Custom Type
 It's easy to add a custom attribute type.
 ```ruby

--- a/lib/fast_attributes/builder.rb
+++ b/lib/fast_attributes/builder.rb
@@ -27,7 +27,7 @@ module FastAttributes
       end
 
       if @options[:attributes]
-        compile_attributes
+        compile_attributes(@options[:attributes])
       end
 
       include_methods
@@ -68,10 +68,15 @@ module FastAttributes
       EOS
     end
 
-    def compile_attributes
+    def compile_attributes(mode)
       attributes = @attributes.flat_map(&:first)
+      prefix = case mode
+               when :accessors then ''
+               else '@'
+               end
+
       attributes = attributes.map do |attribute|
-        "'#{attribute}' => @#{attribute}"
+        "'#{attribute}' => #{prefix}#{attribute}"
       end
 
       @methods.module_eval <<-EOS, __FILE__, __LINE__ + 1

--- a/spec/fast_attributes_spec.rb
+++ b/spec/fast_attributes_spec.rb
@@ -380,6 +380,11 @@ describe FastAttributes do
         klass = AttributesWithAccessors.new(pages: 10, title: 'Something')
         expect(klass.attributes).to eq({'pages' => 20, 'title' => 'A Longer Title: Something', 'color' => 'white'})
       end
+
+      it 'works with default attributes' do
+        klass = AttributesWithAccessorsAndDefaults.new
+        expect(klass.attributes).to eq({'pages' => 20, 'title' => 'a title'})
+      end
     end
   end
 

--- a/spec/fast_attributes_spec.rb
+++ b/spec/fast_attributes_spec.rb
@@ -363,5 +363,26 @@ describe FastAttributes do
         expect(reader.attributes).to eq({'name' => '102', 'age' => 25})
       end
     end
+
+    describe 'option attributes: :accessors' do
+      it 'generates attributes method' do
+        publisher = Publisher.new
+        expect(publisher.attributes).to eq({'name' => nil, 'books' => nil})
+
+        reader = Reader.new
+        expect(reader.attributes).to eq({'name' => nil, 'age' => nil})
+      end
+
+      it "is returns the values of accessors, not the ivars" do
+        klass = AttributesWithAccessors.new(pages: 10, title: 'Something')
+        expect(klass.attributes['pages']).to be(20)
+        expect(klass.attributes['title']).to eq('A Longer Title: Something')
+      end
+
+      it 'is possible to override attributes method' do
+        klass = AttributesWithAccessors.new(pages: 10, title: 'Something')
+        expect(klass.attributes).to eq({'pages' => 20, 'title' => 'A Longer Title: Something', 'color' => 'white'})
+      end
+    end
   end
 end

--- a/spec/fixtures/classes.rb
+++ b/spec/fixtures/classes.rb
@@ -152,6 +152,19 @@ class AttributesWithAccessors
   end
 end
 
+class AttributesWithAccessorsAndDefaults
+  extend FastAttributes
+
+  define_attributes initialize: true, attributes: :accessors do
+    attribute :title, String, default: "a title"
+    attribute :pages, Integer, default: 10
+  end
+
+  def pages
+    @pages + 10
+  end
+end
+
 class ClassWithDefaults
   extend FastAttributes
 

--- a/spec/fixtures/classes.rb
+++ b/spec/fixtures/classes.rb
@@ -113,3 +113,24 @@ class DefaultLenientAttributes
   attribute :rate,      :float
   attribute :active,    :boolean
 end
+
+class AttributesWithAccessors
+  extend FastAttributes
+
+  define_attributes initialize: true, attributes: :accessors do
+    attribute :title, :string
+    attribute :pages, :integer
+  end
+
+  def attributes
+    super.merge('color' => 'white')
+  end
+
+  def pages
+    @pages + 10
+  end
+
+  def title
+    "A Longer Title: #{@title}"
+  end
+end


### PR DESCRIPTION
- Slightly slower than using ivars, hence the need for a new option, but allows you to override the getters and still have them returned via the `attributes` call.